### PR TITLE
PageRegular::prepare is called

### DIFF
--- a/src/PageType/FolderPage.php
+++ b/src/PageType/FolderPage.php
@@ -28,4 +28,17 @@ class FolderPage extends PageRegular
     {
         throw new PageNotFoundException();
     }
+
+    /**
+     * Generate a 404 page if this page is rendered in the frontend.
+     *
+     * @param \PageModel $objPage
+     * @param bool       $blnCheckRequest
+     *
+     * @throws PageNotFoundException
+     */
+    public function getResponse($objPage, $blnCheckRequest=false)
+    {
+        throw new PageNotFoundException();
+    }
 }


### PR DESCRIPTION
Contao uses `getResponse()` for generating a page. However this would generate the page. This PR prevents it by throwing also a PageNotFoundException.