### PR TITLE
Add pageTitle to folder palette

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -27,7 +27,7 @@ foreach ($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'] as $k => $ca
 /*
  * Palettes
  */
-$GLOBALS['TL_DCA']['tl_page']['palettes']['folder'] = '{title_legend},title,type;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,hide,guests';
+$GLOBALS['TL_DCA']['tl_page']['palettes']['folder'] = '{title_legend},title,type;{meta_legend},pageTitle;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,hide,guests';
 
 /*
  * Fields


### PR DESCRIPTION
Since pages of type `folder` can appear in different types of navigation (regular navigation, breadcrumb, …) and these navigations also access the `pageTitle`, the `pageTitle` should also be present in the `folder` palette. Otherwise you might run into the following problem:

1. Create a regular page and fill it with a page name _and_ a different page title.
2. Later on decide to make this page a folder page instead.
3. Use a regular or breadcrumb navigation in the front end.

For the folder page, the page title will be used instead of the page name, even though you cannot edit the page title any more.