### PR TITLE
Ignore callables for onload_callback

### DIFF
--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -15,7 +15,7 @@
 $GLOBALS['TL_DCA']['tl_page']['config']['onsubmit_callback'][] = ['terminal42_folderpage.datacontainer.page', 'configureFolderPage'];
 
 foreach ($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'] as $k => $callback) {
-    if (\is_callable($callback)) {
+    if (!\is_array($callback)) {
         continue;
     }
 

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -15,6 +15,10 @@
 $GLOBALS['TL_DCA']['tl_page']['config']['onsubmit_callback'][] = ['terminal42_folderpage.datacontainer.page', 'configureFolderPage'];
 
 foreach ($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'] as $k => $callback) {
+    if (\is_callable($callback)) {
+        continue;
+    }
+
     if ('addBreadcrumb' === $callback[1]) {
         $GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'][$k] = ['terminal42_folderpage.datacontainer.page', 'addBreadcrumb'];
     }


### PR DESCRIPTION
If some extension implemented an `onload_callback` as a closure, the following error will occur:

```
In tl_page.php line 18:
                                              
  [Error]                                     
  Cannot use object of type Closure as array
```

This PR checks for such callables and ignores them during the analysis of `$GLOBALS['TL_DCA']['tl_page']['config']['onload_callback']`.