### PR TITLE
do not force-publish folder pages on save/create

### DIFF
--- a/src/DataContainer/Page.php
+++ b/src/DataContainer/Page.php
@@ -144,7 +144,6 @@ class Page
                 'alias' => '',
                 'noSearch' => '1',
                 'sitemap' => 'map_never',
-                'published' => '1',
                 'start' => '',
                 'stop' => '',
             ],


### PR DESCRIPTION
This fixes the bug with unpublishing folder-page, mentioned in #18, which is still not fixed, due to `onsubmit_callback`. As a result, the page of this type will be initially created "not published", but this is consistent with Contao core.