### PR TITLE
"Unknown option: regular" when creating a new website root

### DIFF
--- a/src/DataContainer/Page.php
+++ b/src/DataContainer/Page.php
@@ -250,27 +250,6 @@ class Page
         return $options;
     }
 
-    public function setRootType(DataContainer $dc): void
-    {
-        if ('create' !== Input::get('act')) {
-            return;
-        }
-
-        // Insert into
-        if (Input::get('pid') == 0) {
-            $GLOBALS['TL_DCA']['tl_page']['fields']['type']['default'] = 'root';
-        } else {
-            $objPage = Database::getInstance()->prepare('SELECT * FROM '.$dc->table.' WHERE id=?')
-                ->limit(1)
-                ->execute(Input::get('pid'))
-            ;
-
-            if ($objPage->pid == 0 && $objPage->type === 'folder') {
-                $GLOBALS['TL_DCA']['tl_page']['fields']['type']['default'] = 'root';
-            }
-        }
-    }
-
     /**
      * Sets a new node if input value is given.
      */

--- a/src/Resources/contao/dca/tl_page.php
+++ b/src/Resources/contao/dca/tl_page.php
@@ -26,10 +26,6 @@ foreach ($GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'] as $k => $ca
     if ('showFallbackWarning' === $callback[1]) {
         $GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'][$k] = ['terminal42_folderpage.datacontainer.page', 'showFallbackWarning'];
     }
-
-    if ('setRootType' === $callback[1]) {
-        $GLOBALS['TL_DCA']['tl_page']['config']['onload_callback'][$k] = ['terminal42_folderpage.datacontainer.page', 'setRootType'];
-    }
 }
 
 /*


### PR DESCRIPTION
See https://github.com/contao/contao/issues/3901

This is still caused by the `onload_callback` (see also https://github.com/terminal42/contao-folderpage/issues/21).

What is the purpose of `Terminal42\FolderpageBundle\DataContainer::setRootType`, i.e. what problem does it attempt to resolve? Removing that custom callback completely would resolve both issues and I do not notice any other issues.