### PR TITLE
allow contao 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^7.4 || ^8.0",
-        "contao/core-bundle": "^4.13",
+        "contao/core-bundle": "^4.13 || ^5.0",
         "doctrine/dbal": "^3"
     },
     "require-dev": {


### PR DESCRIPTION
I couldn't find any bugs, so there should be nothing against supporting Contao 5.