### PR TITLE
Allow setting sitemap properties

### DIFF
--- a/contao/dca/tl_page.php
+++ b/contao/dca/tl_page.php
@@ -3,7 +3,7 @@
 /*
  * Palettes
  */
-$GLOBALS['TL_DCA']['tl_page']['palettes']['folder'] = '{title_legend},title,type;{meta_legend},pageTitle;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,hide,guests;{publish_legend},published';
+$GLOBALS['TL_DCA']['tl_page']['palettes']['folder'] = '{title_legend},title,type;{meta_legend},pageTitle;{protected_legend:hide},protected;{layout_legend:hide},includeLayout;{cache_legend:hide},includeCache;{chmod_legend:hide},includeChmod;{expert_legend:hide},cssClass,sitemap,hide,guests;{publish_legend},published';
 
 /*
  * Fields

--- a/src/EventListener/ConfigureFolderPageListener.php
+++ b/src/EventListener/ConfigureFolderPageListener.php
@@ -34,7 +34,6 @@ class ConfigureFolderPageListener
             [
                 'alias' => '',
                 'noSearch' => '1',
-                'sitemap' => 'map_never',
                 'start' => '',
                 'stop' => '',
                 'robots' => 'noindex,nofollow',


### PR DESCRIPTION
In https://github.com/terminal42/contao-folderpage/pull/11 we introduced that folder pages can be individually hidden in the menu so that they can be part of the regular navigation structure.

However if you use the HTML sitemap module, all folder pages (and their subtree) will never show up there, because `sitemap` is forced to `map_never`.

This PR changes that by also making it configurable whether a folder should show up in the HTML sitemap or not.