### PR TITLE
Fix attribute inheritance within the folger page template

### DIFF
--- a/contao/templates/nav_folderpage.html.twig
+++ b/contao/templates/nav_folderpage.html.twig
@@ -1,22 +1,22 @@
 <ul class="{{ level }}">
     {% for item in items %}
-        {% set item_attributes = attrs()
+        {% set _item_attributes = attrs()
             .addClass(item.class|default)
             .addClass('folder', item.type == 'folder')
             .mergeWith(item_attributes|default)
         %}
-        <li{{ item_attributes }}>
-            {% set link_attributes = attrs()
+        <li{{ _item_attributes }}>
+            {% set _link_attributes = attrs()
                 .addClass(item.class|default)
                 .set('aria-haspopup', 'true', item.subitems is not empty)
                 .mergeWith(link_attributes|default)
             %}
             {% if item.type == 'folder' %}
-                <span{{ link_attributes }}>{{ item.link }}</span>
+                <span{{ _link_attributes }}>{{ item.link }}</span>
             {% elseif item.isActive %}
-                <strong{{ link_attributes }}>{{ item.link }}</strong>
+                <strong{{ _link_attributes }}>{{ item.link }}</strong>
             {% else %}
-                {% set link_attributes = attrs()
+                {% set _link_attributes = attrs()
                     .set('href', item.href|default('./'))
                     .set('title', item.pageTitle|default(item.title))
                     .setIfExists('accesskey', item.accesskey|default)
@@ -25,7 +25,7 @@
                     .mergeWith(item.rel|default)
                     .mergeWith(link_attributes|default)
                 %}
-                <a{{ link_attributes }}>{{ item.link }}</a>
+                <a{{ _link_attributes }}>{{ item.link }}</a>
             {% endif %}
             {{ item.subitems|default('')|raw }}
         </li>


### PR DESCRIPTION
### Description

Fixes #45 by prefixing the attributes and not relying on same name.